### PR TITLE
[WIP] Refactor: async, JSON output, sourcemaps, modern postcss config

### DIFF
--- a/.postcssrc
+++ b/.postcssrc
@@ -1,0 +1,2 @@
+plugins:
+  autoprefixer: {}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - '5'
+  - '6'

--- a/cli.js
+++ b/cli.js
@@ -17,7 +17,7 @@ const cli = meow(`
 `)
 
 build(cli)
-  .catch(err => {
+  .catch(error => {
     console.error(`Unable to build: ${error}`)
     process.exit(1)
   })

--- a/cli.js
+++ b/cli.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable no-console */
 'use strict'
 const meow = require('meow')
 const build = require('./')
@@ -7,6 +8,9 @@ const cli = meow(`
   Usage
     $ primer-module-build [file]
 
+  Options
+    -v, --verbose   Output more verbose info to stderr
+
   File
     File. This is required. The file input is the .scss file that
     will be built into .css. The build automatically looks in the
@@ -14,13 +18,18 @@ const cli = meow(`
 
   Example
     $ primer-module-build index.scss
-`)
+`, {
+  alias: {
+    v: 'verbose',
+  },
+  'boolean': ['v']
+})
 
 build(cli)
   .catch(error => {
     console.error(`Unable to build: ${error}`)
     process.exit(1)
   })
-  .then(output => {
+  .then(() => {
     process.exit(0)
   })

--- a/cli.js
+++ b/cli.js
@@ -17,3 +17,10 @@ const cli = meow(`
 `)
 
 build(cli)
+  .catch(err => {
+    console.error(`Unable to build: ${error}`)
+    process.exit(1)
+  })
+  .then(output => {
+    process.exit(0)
+  })

--- a/index.js
+++ b/index.js
@@ -14,5 +14,5 @@ module.exports = str => {
     throw new InputException("We are only able to handle .scss files")
   }
 
-  build(str.input[0], str.flags)
+  return build(str.input[0], str.flags)
 }

--- a/index.js
+++ b/index.js
@@ -5,14 +5,14 @@ function InputException(message) {
   this.name = "InputException"
 }
 
-module.exports = str => {
-  if (!str.input || str.input.length === 0) {
+module.exports = argv => {
+  if (!argv.input || argv.input.length === 0) {
     throw new InputException("You must supply a file to build")
   }
 
-  if (!str.input[0].match(/\.scss$/)) {
+  if (!argv.input[0].match(/\.scss$/)) {
     throw new InputException("We are only able to handle .scss files")
   }
 
-  return build(str.input[0], str.flags)
+  return build(argv.input[0], argv.flags)
 }

--- a/lib/.postcss.json
+++ b/lib/.postcss.json
@@ -1,6 +1,0 @@
-{
-  "use": ["autoprefixer"],
-  "autoprefixer": {
-    "browsers": "> 5%, last 2 firefox versions, last 2 chrome versions, last 2 safari versions, last 2 edge versions, ie 11"
-  }
-}

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,3 +1,4 @@
+/* eslint-disable func-style */
 const sass = require("node-sass")
 const path = require("path")
 const postcss = require("postcss")

--- a/lib/build.js
+++ b/lib/build.js
@@ -3,16 +3,20 @@ const sass = require("node-sass")
 const path = require("path")
 const postcss = require("postcss")
 const postcssrc = require("postcss-load-config")
-const fs = require("fs")
 const fse = require("fs-extra")
 const cssstats = require("cssstats")
 const promisify = require("pify")
 
 module.exports = (str, opts) => {
 
+  const verbose = opts.verbose
+  const log = verbose
+    ? (...msg) => console.warn(...msg)
+    : () => {}
+
   const cwd = process.cwd()
   const sourceFile = path.join(cwd, str)
-  const outputDir = path.join(cwd, "build")
+  const outputDir = opts.outputDir || path.join(cwd, "build")
   const outputFile = path.join(outputDir, "build.css")
   const outputMapFile = outputFile + ".map"
   const outputDataFile = path.join(outputDir, "stats.json")
@@ -21,7 +25,7 @@ module.exports = (str, opts) => {
   const sassRender = promisify(sass.render)
 
   const build = () => {
-    // console.warn("Sass rendering ...")
+    log("Rendering Sass...")
     return sassRender({
       file: sourceFile,
       includePaths: ["node_modules"],
@@ -31,10 +35,10 @@ module.exports = (str, opts) => {
   }
 
   const postprocess = (res) => {
-    // console.warn("Post-processing...")
+    log("Post-processing...")
     return postcssrc()
       .catch(error => {
-        console.warn("No postcss config found")
+        log("No postcss config found: ", error) // eslint-disable-line no-console
         return {
           plugins: [],
           options: {},
@@ -46,10 +50,12 @@ module.exports = (str, opts) => {
           to: outputFile,
           map: {inline: false},
         })
+        log("Writing CSS to %s ...", options.to)
         return postcss(plugins).process(res.css, options)
       })
       .then(result => {
-        if (result.map) {
+        if (outputMapFile && result.map) {
+          log("Writing sourcemap to %s ...", outputMapFile)
           return fse.writeFile(outputMapFile, result.map)
             .then(() => result)
         }
@@ -57,12 +63,12 @@ module.exports = (str, opts) => {
       })
       .then(result => {
         const stats = cssstats(result.css)
-        // console.warn("Writing stats to %s ...", outputDataFile)
+        log("Writing stats to %s ...", outputDataFile)
         return fse.writeFile(outputDataFile, JSON.stringify(stats))
       })
       .then(() => {
         const dataFile = path.basename(outputDataFile)
-        // console.warn("Writing JS to %s ...", outputJSFile)
+        log("Writing JS to %s ...", outputJSFile)
         return fse.writeFile(outputJSFile, `module.exports = {cssstats: require("./${dataFile}")}`)
       })
   }

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,51 +1,96 @@
-const sass = require('node-sass')
-const postcss = require('postcss')
-const fs = require('fs')
-const cssstats = require('cssstats')
+const sass = require("node-sass")
+const path = require("path")
+const postcss = require("postcss")
+const fs = require("fs")
+const fse = require("fs-extra")
+const cssstats = require("cssstats")
+const promisify = require("pify")
 
-module.exports = (str, flags) => {
-
-  const sourceFile = `${process.cwd()}/${str}`
-  const outputFile = `${process.cwd()}/build/build.css`
-  const outputDataFile = `${process.cwd()}/build/index.js`
-
-  // make the build direcotry if it doesn't exist
-  fs.mkdir(`${process.cwd()}/build`, (err) => {
-    if (err && err.errno !== -17) {
-      throw err
+const postcssrc = (filename, baseDir = "") => {
+  const defaultFilename = ".postcss.json"
+  filename = filename || defaultFilename
+  let rc
+  return [
+    path.join(baseDir, filename),
+    path.join("./", defaultFilename),
+  ].some(filePath => {
+    try {
+      return rc = require(filePath)
+    } catch (error) {
+      // console.warn('unable to require("%s")', filePath)
     }
   })
+}
 
-  function postcssPlugins() {
-    const postcssrc = (() => {
-      if (flags.postcssconfig && fs.existsSync(`${process.cwd()}/${flags.postcssconfig}`)) {
-        return require(`${process.cwd()}/${flags.postcssconfig}`)
-      } else if (fs.existsSync(`${process.cwd()}/.postcss.json`)) {
-        return require(`${process.cwd()}/.postcss.json`)
-      } else {
-        return require('./.postcss.json')
-      }
-    })()
+module.exports = (str, opts) => {
 
-    return postcssrc.use.map(name => {
+  const cwd = process.cwd()
+  const sourceFile = path.join(cwd, str)
+  const outputDir = path.join(cwd, "build")
+  const outputFile = path.join(outputDir, "build.css")
+  const outputMapFile = outputFile + ".map"
+  const outputDataFile = path.join(outputDir, "stats.json")
+  const outputJSFile = path.join(outputDir, "index.js")
+
+  const postcssPlugins = () => {
+    const rc = postcssrc(opts.postcssconfig)
+    return rc ? rc.use.map(name => {
       return require(name)(postcssrc[name])
+    }) : []
+  }
+
+  const sassRender = promisify(sass.render)
+
+  const build = () => {
+    // console.warn("Sass rendering ...")
+    return sassRender({
+      file: sourceFile,
+      includePaths: ["node_modules"],
+      outputStyle: "compressed",
+      sourceMap: true,
     })
   }
 
-  // Compile the sass
-  const sassOutput = sass.renderSync({
-    file: sourceFile,
-    includePaths: ['node_modules'],
-    outputStyle: 'compressed'
-  })
+  const postprocess = (res) => {
+    const post = postcss(postcssPlugins())
+    // console.warn("Post-processing...")
+    return post.process(res.css, {
+        from: sourceFile,
+        to: outputFile,
+        map: {inline: false},
+      })
+      .then(result => {
+        // console.warn("Writing CSS to %s ...", outputFile)
+        return fse.writeFile(outputFile, result.css)
+          .then(() => {
+            if (result.map) {
+              // console.warn("Writing sourcemap to %s ...", outputMapFile)
+              return fse.writeFile(outputFile + ".map", result.map)
+            } else {
+              // console.warn("(No source map)")
+            }
+          })
+          .then(() => result.css)
+      })
+      .then(css => {
+        const stats = cssstats(css)
+        // console.warn("Writing stats to %s ...", outputDataFile)
+        return fse.writeFile(outputDataFile, JSON.stringify(stats))
+      })
+      .then(() => {
+        const dataFile = path.basename(outputDataFile)
+        // console.warn("Writing JS to %s ...", outputJSFile)
+        return fse.writeFile(outputJSFile, `module.exports = {cssstats: require("./${dataFile}")}`)
+      })
+  }
 
-  // Process postcss
-  postcss(postcssPlugins()).process(sassOutput.css.toString(), {from: sourceFile, to: outputFile}).then(result => {
-    fs.writeFileSync(outputFile, result.css)
-
-    const data = {
-      "cssstats": cssstats(result.css)
-    }
-    fs.writeFileSync(outputDataFile, `module.exports = ${JSON.stringify(data)}`)
-  })
+  return fse.mkdirp(path.dirname(outputFile))
+    .then(build)
+    .then(postprocess)
+    .then(() => ({
+      css: outputFile,
+      sourcemap: outputMapFile,
+      data: outputDataFile,
+      js: outputJSFile,
+    }))
 }

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,26 +1,11 @@
 const sass = require("node-sass")
 const path = require("path")
 const postcss = require("postcss")
+const postcssrc = require("postcss-load-config")
 const fs = require("fs")
 const fse = require("fs-extra")
 const cssstats = require("cssstats")
 const promisify = require("pify")
-
-const postcssrc = (filename, baseDir = "") => {
-  const defaultFilename = ".postcss.json"
-  filename = filename || defaultFilename
-  let rc
-  return [
-    path.join(baseDir, filename),
-    path.join("./", defaultFilename),
-  ].some(filePath => {
-    try {
-      return rc = require(filePath)
-    } catch (error) {
-      // console.warn('unable to require("%s")', filePath)
-    }
-  })
-}
 
 module.exports = (str, opts) => {
 
@@ -31,13 +16,6 @@ module.exports = (str, opts) => {
   const outputMapFile = outputFile + ".map"
   const outputDataFile = path.join(outputDir, "stats.json")
   const outputJSFile = path.join(outputDir, "index.js")
-
-  const postcssPlugins = () => {
-    const rc = postcssrc(opts.postcssconfig)
-    return rc ? rc.use.map(name => {
-      return require(name)(postcssrc[name])
-    }) : []
-  }
 
   const sassRender = promisify(sass.render)
 
@@ -52,12 +30,19 @@ module.exports = (str, opts) => {
   }
 
   const postprocess = (res) => {
-    const post = postcss(postcssPlugins())
     // console.warn("Post-processing...")
-    return post.process(res.css, {
-        from: sourceFile,
-        to: outputFile,
-        map: {inline: false},
+    return postcssrc()
+      .catch(error => {
+        console.warn("No postcss config found")
+        return {plugins: [], options: {}}
+      })
+      .then(({plugins, options}) => {
+        Object.assign(options, {
+          from: sourceFile,
+          to: outputFile,
+          map: {inline: false},
+        })
+        return postcss(plugins).process(res.css, options)
       })
       .then(result => {
         // console.warn("Writing CSS to %s ...", outputFile)

--- a/lib/build.js
+++ b/lib/build.js
@@ -34,7 +34,10 @@ module.exports = (str, opts) => {
     return postcssrc()
       .catch(error => {
         console.warn("No postcss config found")
-        return {plugins: [], options: {}}
+        return {
+          plugins: [],
+          options: {},
+        }
       })
       .then(({plugins, options}) => {
         Object.assign(options, {
@@ -45,20 +48,14 @@ module.exports = (str, opts) => {
         return postcss(plugins).process(res.css, options)
       })
       .then(result => {
-        // console.warn("Writing CSS to %s ...", outputFile)
-        return fse.writeFile(outputFile, result.css)
-          .then(() => {
-            if (result.map) {
-              // console.warn("Writing sourcemap to %s ...", outputMapFile)
-              return fse.writeFile(outputFile + ".map", result.map)
-            } else {
-              // console.warn("(No source map)")
-            }
-          })
-          .then(() => result.css)
+        if (result.map) {
+          return fse.writeFile(outputMapFile, result.map)
+            .then(() => result)
+        }
+        return result
       })
-      .then(css => {
-        const stats = cssstats(css)
+      .then(result => {
+        const stats = cssstats(result.css)
         // console.warn("Writing stats to %s ...", outputDataFile)
         return fse.writeFile(outputDataFile, JSON.stringify(stats))
       })

--- a/lib/build.js
+++ b/lib/build.js
@@ -11,7 +11,7 @@ module.exports = (str, opts) => {
 
   const verbose = opts.verbose
   const log = verbose
-    ? (...msg) => console.warn(...msg)
+    ? (...msg) => console.warn(...msg) // eslint-disable-line no-console
     : () => {}
 
   const cwd = process.cwd()
@@ -38,7 +38,7 @@ module.exports = (str, opts) => {
     log("Post-processing...")
     return postcssrc()
       .catch(error => {
-        log("No postcss config found: ", error) // eslint-disable-line no-console
+        log("No postcss config found: ", error)
         return {
           plugins: [],
           options: {},

--- a/package.json
+++ b/package.json
@@ -36,8 +36,10 @@
   "dependencies": {
     "autoprefixer": "^6.7.7",
     "cssstats": "^3.0.0-beta.2",
+    "fs-extra": "^4.0.1",
     "meow": "^3.7.0",
     "node-sass": "^4.3.0",
+    "pify": "^3.0.0",
     "postcss": "^5.2.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "meow": "^3.7.0",
     "node-sass": "^4.3.0",
     "pify": "^3.0.0",
-    "postcss": "^5.2.5"
+    "postcss": "^5.2.5",
+    "postcss-load-config": "^1.2.0"
   },
   "devDependencies": {
     "ava": "^0.18.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,14 @@
     "lint": "eslint lib/**/*.js *.js tests/**/*.js",
     "test": "npm run lint && npm run ava"
   },
+  "browserslist": [
+    "> 5%",
+    "last 2 firefox versions",
+    "last 2 chrome versions",
+    "last 2 safari versions",
+    "last 2 edge versions",
+    "ie 11"
+  ],
   "keywords": [
     "primer",
     "build",

--- a/tests/index.js
+++ b/tests/index.js
@@ -5,8 +5,8 @@ const build = require("../lib/build.js")
 test("builds test css", t => {
   return build("./tests/test.scss", {})
     .then(output => {
-      Object.entries(output).forEach(([key, file]) => {
-        t.is(fs.existsSync(file), true, `No ${key} output: ${file}`)
+      Object.keys(output).forEach(key => {
+        t.is(fs.existsSync(output[key]), true, `No ${key} output: ${output[key]}`)
       })
     })
 })

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,10 +1,12 @@
+const fs = require("fs")
 const test = require("ava")
 const build = require("../lib/build.js")
 
 test("builds test css", t => {
-  try {
-    build("./tests/test.scss", {})
-  } catch (e) {
-    t.fail(e.message)
-  }
+  return build("./tests/test.scss", {})
+    .then(output => {
+      Object.entries(output).forEach(([key, file]) => {
+        t.is(fs.existsSync(file), true, `No ${key} output: ${file}`)
+      })
+    })
 })


### PR DESCRIPTION
This is an overhaul of our build utility. Here's what it does:

- [x] Refactor for chained asynchronous execution with promises ✨ 
- [x] Replace the `.postcss.json` loading logic with [postcss-load-config](https://github.com/michael-ciniawsky/postcss-load-config)
- [x] Migrate `lib/.postcss.json` to [`.postcssrc`](https://github.com/michael-ciniawsky/postcss-load-config#postcssrc) in YAML format
- [x] Output cssstats to `build/stats.json`, and modify `build/index.js` output to `require("./stats.json")` - fixes #18 
- [x] Write sourcemaps to `build/build.css.map` for easier debugging
- [x] Update our single unit test to ensure that all of the output files exist after building successfully
- [x] Add `-v/--verbose` option to log each step as it goes